### PR TITLE
Password prompt fix

### DIFF
--- a/bin/eyaml
+++ b/bin/eyaml
@@ -33,7 +33,7 @@ def get_input(options)
   return options[:string] if options[:string]
 
   if options[:password]
-    ask("Enter password: ") {|q| q.echo = "*" }
+    return ask("Enter password: ") {|q| q.echo = "*" }
   end
 
   get_file_input(options)


### PR DESCRIPTION
Add missing return statement in get_input function, without this eyaml will wait for stdin when using -p / --password
