### PR TITLE
Fix the encrypt action

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ things:
         - nested thing 2.1
 </pre>
 
+Tests
+=====
+
+In order to run the tests, simply run `cucumber` in the top level directory of the project.
+
+You'll need to have a few requirements installed:
+
+  * `expect` (via yum/apt-get or system package)
+  * `aruba` (gem)
+  * `cucumber` (gem)
+  * `puppet` (gem)
+
 Notes
 =====
 

--- a/features/encrypts.feature
+++ b/features/encrypts.feature
@@ -12,6 +12,10 @@ Feature: eyaml encrypting
     When I run `eyaml -e -o string -f test_input.txt`
     Then the output should match /ENC\[PKCS7,(.*?)\]$/
 
+  Scenario: encrypt a eyaml file
+    When I run `eyaml -e --eyaml test_plain.yaml`
+    Then the output should match /key: ENC\[PKCS7,(.*?)\]$/
+
   Scenario: encrypt a binary file
     When I run `eyaml -e -o string -f test_input.bin`
     Then the output should match /ENC\[PKCS7,(.*?)\]$/

--- a/features/sandbox/test_plain.yaml
+++ b/features/sandbox/test_plain.yaml
@@ -1,0 +1,2 @@
+---
+key: DEC::PKCS7[value to encrypt]!

--- a/lib/hiera/backend/eyaml/actions/encrypt_action.rb
+++ b/lib/hiera/backend/eyaml/actions/encrypt_action.rb
@@ -12,7 +12,7 @@ class Hiera
 
           def self.execute 
 
-            output_data = case Eyaml::Options[:source]
+            case Eyaml::Options[:source]
             when :eyaml
               encryptions = []
 
@@ -26,7 +26,7 @@ class Hiera
               }
 
               # strings
-              output.gsub!( REGEX_DECRYPTED_STRING ) { |match|
+              output.gsub( REGEX_DECRYPTED_STRING ) { |match|
                 encryption_scheme = parse_encryption_scheme( $1 )
                 encryptor = Encryptor.find encryption_scheme
                 ciphertext = encryptor.encode( encryptor.encrypt($2) ).gsub(/\n/, "")
@@ -36,10 +36,8 @@ class Hiera
             else
               encryptor = Encryptor.find
               ciphertext = encryptor.encode( encryptor.encrypt(Eyaml::Options[:input_data]) )
-              "ENC[#{encryptor.tag},#{ciphertext}]"
+              self.format :data => "ENC[#{encryptor.tag},#{ciphertext}]", :structure => Eyaml::Options[:output], :label => Eyaml::Options[:label]
             end
-
-            self.format :data => output_data, :structure => Eyaml::Options[:output], :label => Eyaml::Options[:label]
 
           end
 


### PR DESCRIPTION
The action previously tried to use code for formatting the output (according
to the --output option) even when it was transforming a eyaml file. This made
no sense and resulting in a series of exceptions and problems.

Added a test that encrypts using the command that previously broke for me.

Passes test suite.
