### PR TITLE
Tidy up logging and add debug / quiet modes

### DIFF
--- a/lib/hiera/backend/eyaml/CLI.rb
+++ b/lib/hiera/backend/eyaml/CLI.rb
@@ -33,17 +33,19 @@ Options:
   EOS
           
             opt :createkeys, "Create public and private keys for use encrypting properties", :short => 'c'
-            opt :decrypt, "Decrypt something"
-            opt :encrypt, "Encrypt something"
-            opt :edit, "Decrypt, Edit, and Reencrypt", :type => :string
-            opt :eyaml, "Source input is an eyaml file", :type => :string
+            opt :decrypt, "Decrypt something", :short => 'd'
+            opt :encrypt, "Encrypt something", :short => 'e'
+            opt :edit, "Decrypt, Edit, and Reencrypt", :short => 'i', :type => :string
+            opt :eyaml, "Source input is an eyaml file", :short => 'y', :type => :string
             opt :password, "Source input is a password entered on the terminal", :short => 'p'
             opt :string, "Source input is a string provided as an argument", :short => 's', :type => :string
             opt :file, "Source input is a file", :short => 'f', :type => :string
-            opt :stdin, "Source input it taken from stdin", :short => 'z'
+            opt :stdin, "Source input is taken from stdin", :short => :none
             opt :encrypt_method, "Override default encryption and decryption method (default is PKCS7)", :short => 'n', :default => "pkcs7"
-            opt :output, "Output format of final result (examples, block, string)", :type => :string, :default => "examples"
+            opt :output, "Output format of final result (examples, block, string)", :type => :string, :short => 'o', :default => "examples"
             opt :label, "Apply a label to the encrypted result", :short => 'l', :type => :string
+            opt :debug, "Be more verbose", :short => :none
+            opt :quiet, "Be less verbose", :short => :none
 
             Hiera::Backend::Eyaml::Plugins.options.each do |name, option|
               opt name, option[:desc], :type => option[:type], :short => option[:short], :default => option[:default]
@@ -90,6 +92,7 @@ Options:
 
           Eyaml.default_encryption_scheme = options[:encrypt_method].upcase if options[:encrypt_method]
           Eyaml::Options.set options
+          Eyaml::Options.debug
 
         end
 
@@ -98,7 +101,8 @@ Options:
           action = Eyaml::Options[:action]
           action_class = Module.const_get('Hiera').const_get('Backend').const_get('Eyaml').const_get('Actions').const_get("#{Utils.camelcase action.to_s}Action")
 
-          puts action_class.execute
+          return_value = action_class.execute
+          puts return_value unless return_value.nil?
 
         end          
 

--- a/lib/hiera/backend/eyaml/actions/edit_action.rb
+++ b/lib/hiera/backend/eyaml/actions/edit_action.rb
@@ -36,7 +36,7 @@ class Hiera
               file.write encrypted_output
             }
 
-            true
+            nil
           end
 
         end

--- a/lib/hiera/backend/eyaml/encryptor.rb
+++ b/lib/hiera/backend/eyaml/encryptor.rb
@@ -77,7 +77,7 @@ class Hiera
             if self.hiera?
               Hiera.debug format_message msg
             else
-              STDERR.puts format_message msg
+              Utils::debug format_message msg
             end
           end
 
@@ -85,7 +85,7 @@ class Hiera
             if self.hiera?
               Hiera.warn format_message msg
             else
-              STDERR.puts format_message msg
+              Utils::info format_message msg
             end
           end
 

--- a/lib/hiera/backend/eyaml/options.rb
+++ b/lib/hiera/backend/eyaml/options.rb
@@ -21,9 +21,12 @@ class Hiera
         end
 
         def self.debug
+          Utils::debug "Dump of eyaml tool options dict:"
+          Utils::debug "--------------------------------"
           @@options.each do |k, v|
-            puts "#{k.class.name}:#{k} = #{v.class.name}:#{v}"
+            Utils::debug "#{k.class.name}:#{k} = #{v.class.name}:#{v}"
           end
+          Utils::debug ""
         end
 
       end

--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -72,12 +72,20 @@ class Hiera
           unless File.directory? key_dir
             begin
               FileUtils.mkdir_p key_dir
-              puts "Created key directory: #{key_dir}"
+              Utils::info "Created key directory: #{key_dir}"
             rescue
               raise StandardError, "Cannot create key directory: #{key_dir}"
             end
           end
 
+        end
+
+        def self.info message
+          STDERR.puts message unless Eyaml::Options[:quiet]
+        end
+
+        def self.debug message
+          STDERR.puts message if Eyaml::Options[:debug]
         end
 
       end


### PR DESCRIPTION
Added a very simple logging and debug framework, adding two new command line options (`--debug` and `--quiet`) and two new methods in the Utils class (`debug` and `info`).

`--debug` will print all messages to STDERR, `--quiet` will print no messages whilst the default state is to print messages sent to the `info` method, but not to the `debug` method.

At startup, the Options.debug method is now called every time, although it uses the debug method to output the information and so will only appear when the `--debug` flag is used.

Also, the return value of an action is now only printed when it is not `nil`. The `edit` action has been modified to return `nil`.

Finally, I also tidied up the short options so those that are used frequently are explicitly provided.
