### PR TITLE
Allow plugins to be detected when using Gem version < 1.8

### DIFF
--- a/lib/hiera/backend/eyaml/plugins.rb
+++ b/lib/hiera/backend/eyaml/plugins.rb
@@ -40,7 +40,7 @@ class Hiera
               if Gem::VERSION >= "1.8.0"
                 file = spec.matches_for_glob("**/eyaml_init.rb").first
               else
-                file = Gem.searcher.matching_files(spec, "eyaml_init.rb").first
+                file = Gem.searcher.matching_files(spec, "**/eyaml_init.rb").first
               end
 
               next unless file


### PR DESCRIPTION
The glob pattern for Gem version < 1.8 does not look recursively in the require_paths. This means that plugins like the hiera-eyaml-gpg can not register when using an older rubygem version.
