### PR TITLE
support hiera's deep merge for hashes

### DIFF
--- a/lib/hiera/backend/eyaml_backend.rb
+++ b/lib/hiera/backend/eyaml_backend.rb
@@ -41,7 +41,7 @@ class Hiera
               debug("Merging answer hash")
               raise Exception, "Hiera type mismatch: expected Hash and got #{parsed_answer.class}" unless parsed_answer.kind_of? Hash
               answer ||= {}
-              answer = parsed_answer.merge answer
+              answer = Backend.merge_answer(parsed_answer,answer)
             else
               debug("Assigning answer variable")
               answer = parsed_answer


### PR DESCRIPTION
This changes the way hashes are merged in the hiera eyaml backend, by calling hiera's own Backend.merge_answer method - this uses a deep merge, depending on the presence of the deep_merge gem and hiera configuration.
