### PR TITLE
[FIX] multiline block parse

### DIFF
--- a/features/parser.feature
+++ b/features/parser.feature
@@ -33,10 +33,13 @@ Feature: Parser
     Given I make a parser instance with the DEC regexs
     And I load a file called test_plain_with_index.yaml
     When I parse the content
-    Then I should have 2 tokens
+    Then I should have 5 tokens
     Then token 1 should be a NonMatchToken
     Then token 2 should be a EncToken
     Then token 2 id should be 23
+    Then token 3 should be a NonMatchToken
+    Then token 4 should be a EncToken
+    Then token 4 id should be 24
 
   Scenario: Output indexed decryption tokens
     Given I make a parser instance with the ENC regexs

--- a/features/sandbox/test_plain_with_index.yaml
+++ b/features/sandbox/test_plain_with_index.yaml
@@ -1,2 +1,7 @@
 ---
 key: DEC(23)::PKCS7[value to encrypt]!
+
+block: >
+    DEC(24)::PKCS7[block of values
+to encrypt on multiple
+lines]!

--- a/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
+++ b/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
@@ -120,7 +120,7 @@ class Hiera
 
         class DecBlockTokenType < TokenType
           def initialize
-            @regex = />\n(\s*)DEC(\(\d+\))?::(\w+)\[(.+?)\]\!/
+            @regex = />\n(\s*)DEC(\(\d+\))?::(\w+)\[(.+?)\]\!/m
           end
           def create_token(string)
             md = @regex.match(string)


### PR DESCRIPTION
Hi,

With eyaml -i <file> containing multiline blocks I found the block was decrypted but on save left in that state.

Test:

eyaml -i test_input.yaml

change one of the blocks to include multiple lines, save and diff,

```
+    DEC(23)::PKCS7[the pink panther
+and some more]!
   - >
```

and the intermediary format is left behind in the saved file.
