### PR TITLE
Revamp readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ hiera-eyaml is a backend for Hiera that provides per-value encryption of sensiti
 to be used by Puppet.
 
 
-Why not use hiera-gpg?
-----------------------
+Advantages over hiera-gpg
+-------------------------
 
 A few people found that [hiera-gpg](https://github.com/crayfishx/hiera-gpg) just wasn't cutting it for all use cases, 
 one of the best expressed frustrations was 


### PR DESCRIPTION
As mentioned in #37, we wanted to clean up the README to make the benefits / USPs of the project more accessible to those who come past.

This is a first pass of improvements - you can see it in situ at https://github.com/sihil/hiera-eyaml/tree/sihil-revamp-readme#readme
