### PR TITLE
Fix the decrypted tempfile might be deleted before it is securely erased

### DIFF
--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -46,7 +46,9 @@ class Hiera
         def self.write_tempfile data_to_write
           file = Tempfile.open('eyaml_edit')
           path = file.path
+          file.close!
 
+          file = File.open(path, "w")
           file.puts data_to_write
           file.close
 


### PR DESCRIPTION
Sample Exception (ruby 1.9.3p448):

```
vendor/bundle/ruby/1.9.1/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/utils.rb:36:in `initialize':
    No such file or directory -
    /var/folders/pf/z8kdlj_x1kj6zp70h0mbj3yr0000gn/T/eyaml_edit20131203-57895-h4r6cn (Errno::ENOENT)

    from vendor/bundle/ruby/1.9.1/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/utils.rb:36:in `open'
    from vendor/bundle/ruby/1.9.1/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/utils.rb:36:in `secure_file_delete'
    from vendor/bundle/ruby/1.9.1/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/actions/edit_action.rb:77:in `execute'
    from vendor/bundle/ruby/1.9.1/gems/hiera-eyaml-1.3.8/lib/hiera/backend/eyaml/CLI.rb:110:in `execute'
    from vendor/bundle/ruby/1.9.1/gems/hiera-eyaml-1.3.8/bin/eyaml:13:in `<top (required)>'
    from bin/eyaml:23:in `load'
    from bin/eyaml:23:in `<main>'
    from bin/ruby_executable_hooks:15:in `eval'
    from bin/ruby_executable_hooks:15:in `<main>'
```

The root cause is a Tempfile instance will be deleted by the ruby VM at an
unknown time when the instance is recycled by gc after it is closed. The
solution is to use Tempfile as a random file name generation method
only. Tempfile.close!() can guarantee the file is deleted immediately
when it is called. So the later manually created file is safe.

reference:
http://po-ru.com/diary/the-case-of-the-mysteriously-disappearing-file/
