### PR TITLE
utils.rb: fix undefined local variable bug

### DIFF
--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -140,7 +140,7 @@ class Hiera
           message = self.structure_message messageinfo
           message = "[#{message[:from]}] !!! #{message[:msg]}"
           if self.hiera?
-            Hiera.warn format_message msg
+            Hiera.warn format_message message
           else
             STDERR.puts message
           end


### PR DESCRIPTION
I encountered this bug after I tried to decrypt data on a server that wasn't in the correct recipients file, which I'm guessing would raise a warning.
