### PR TITLE
Read private & public key paths from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ access to a DEV branch will be able to read/view the contents of the PRD branch,
 Github has a great guide on removing sensitive data from repos here:
 https://help.github.com/articles/remove-sensitive-data
 
+Private & Public key locations can be defined in ~/.eyaml/config.yaml as such:
+
+```
+private_key: '~/keys/eyaml/private_key.pkcs7.pem'
+public_key: '~/keys/eyaml/public_key.pkcs7.pem'
+```
 
 Troubleshooting
 ---------------

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,6 @@
-ENV['RUBYLIB'] = File.dirname(__FILE__) + '/../../lib'
+rubylib = (ENV["RUBYLIB"] || "").split(File::PATH_SEPARATOR)
+rubylib.unshift %|#{File.dirname(__FILE__) + '/../../lib'}|
+ENV["RUBYLIB"] = rubylib.uniq.join(File::PATH_SEPARATOR)
 require 'rubygems'
 require 'aruba/config'
 require 'aruba/cucumber'

--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -1,4 +1,5 @@
 require 'openssl'
+require 'yaml'
 require 'hiera/backend/eyaml/encryptor'
 require 'hiera/backend/eyaml/utils'
 require 'hiera/backend/eyaml/options'
@@ -9,14 +10,24 @@ class Hiera
       module Encryptors
 
         class Pkcs7 < Encryptor
+          @config_file="#{ENV['HOME']}/.eyaml/config.yaml"
+
+          @eyaml_defaults={"private_key"=>"./keys/private_key.pkcs7.pem",
+                           "public_key" =>"./keys/public_key.pkcs7.pem" }
+
+          @eyaml_config = begin
+            YAML.load_file(@config_file)
+          rescue Errno::ENOENT, IndexError
+            @eyaml_defaults
+          end
 
           self.options = {
-            :private_key => { :desc => "Path to private key", 
-                              :type => :string, 
-                              :default => "./keys/private_key.pkcs7.pem" },
-            :public_key => { :desc => "Path to public key",  
-                             :type => :string, 
-                             :default => "./keys/public_key.pkcs7.pem" }
+            :private_key => { :desc => "Path to private key",
+                              :type => :string,
+                              :default => @eyaml_config.fetch('private_key',@eyaml_defaults["private_key"]) },
+            :public_key  => { :desc => "Path to public key",
+                              :type => :string,
+                              :default => @eyaml_config.fetch('public_key',@eyaml_defaults["public_key"]) }
           }
 
           self.tag = "PKCS7"


### PR DESCRIPTION
Fixes #18 & #71 
Read private_key and public_key from ~/.eyaml/config.yaml

private_key: '~/keys/eyaml/private_key.pkcs7.pem'
public_key: '~/keys/eyaml/public_key.pkcs7.pem'
