### PR TITLE
Fix up msg to message and remove format call

### DIFF
--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -140,7 +140,7 @@ class Hiera
           message = self.structure_message messageinfo
           message = "[#{message[:from]}] !!! #{message[:msg]}"
           if self.hiera?
-            Hiera.warn format_message msg
+            Hiera.warn message
           else
             STDERR.puts message
           end


### PR DESCRIPTION
This fixes a bug raised in #75 and half fixed in #63 which manifests itself when the eyaml code has a problem whilst being run under hiera.
