### PR TITLE
remove hiera gem dependency

### DIFF
--- a/hiera-eyaml.gemspec
+++ b/hiera-eyaml.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('hiera', '>= 1.2.1')
   gem.add_dependency('trollop', '>= 2.0')
   gem.add_dependency('highline', '>= 1.6.19')
 end


### PR DESCRIPTION
The Hiera dependency is not required and it buggers up people trying to
use this with Puppet Enterprise packaged Hiera.

Fixes #80
