### PR TITLE
Add yaml extension to the tempfile

### DIFF
--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -49,7 +49,7 @@ class Hiera
         end
 
         def self.write_tempfile data_to_write
-          file = Tempfile.open('eyaml_edit')
+          file = Tempfile.open(['eyaml_edit', '.yaml'])
           path = file.path
           file.close!
 


### PR DESCRIPTION
When you write yaml using Vim or another editor which supports filetypes (http://vimdoc.sourceforge.net/htmldoc/filetype.html), it is useful to have an extension for the automated detection of the filetype.

Here I've just added the .yaml extension.
