### PR TITLE
Create temporary .yaml file

### DIFF
--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -49,7 +49,7 @@ class Hiera
         end
 
         def self.write_tempfile data_to_write
-          file = Tempfile.open('eyaml_edit')
+          file = Tempfile.open(['eyaml_edit', '.yaml'])
           path = file.path
           file.close!
 


### PR DESCRIPTION
Ensure that the temporary file on edit is a yaml file.

It allows editors which are basing their syntax colouring on the extension of the file.
