### PR TITLE
Added documentation for installing for new puppet-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Setup
 
     $ gem install hiera-eyaml
 
+### Installing hiera-eyaml for the new [puppet-server](https://github.com/puppetlabs/puppet-server)
+
+    $ puppetserver gem install hiera-eyaml
+
 ### Generate keys
 
 The first step is to create a pair of keys:


### PR DESCRIPTION
The [new](https://github.com/puppetlabs/puppet-server) puppet server [requires](https://github.com/puppetlabs/puppet-server/blob/master/documentation/gems.markdown) gems to be installed through the puppetserver command line.  I have updated the documentation to include how to install hiera-eyaml using the puppetserver command line.
