### PR TITLE
hiera-eyaml-plaintext required for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ You'll need to have a few requirements installed:
   * `aruba` (gem)
   * `cucumber` (gem)
   * `puppet` (gem)
+  * `hiera-eyaml-plaintext` (gem)
 
 
 Authors


### PR DESCRIPTION
I always forget that you need the plaintext plugin in order to successfully
run the test suite.
