### PR TITLE
Remove extraneous newline when adding preamble

### DIFF
--- a/lib/hiera/backend/eyaml/subcommands/edit.rb
+++ b/lib/hiera/backend/eyaml/subcommands/edit.rb
@@ -47,7 +47,7 @@ file) will be removed when you save and exit.
    e.g. #{tags.collect {|tag| "DEC::#{tag}[]!" }.join(' -or- ')}
 eos
 
-            preamble.gsub(/^/, "#{self.prefix} ") + $/
+            preamble.gsub(/^/, "#{self.prefix} ")
           end
 
           def self.validate options


### PR DESCRIPTION
Fix issue raised in #120, following @elyscape suggestion
