### PR TITLE
Add ability to read encryption data from single files, as opposed to just .eyaml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ hiera-eyaml is a backend for Hiera that provides per-value encryption of sensiti
 to be used by Puppet.
 
 :new: *v2.0 - commandline tool syntax has changed, see below for details*
+:new: *v2.1 - hiera-eyaml supports reading encrypted data from a file like hiera-file
 
 Advantages over hiera-gpg
 -------------------------
@@ -231,6 +232,32 @@ things:
             IZGeunzwhqfmEtGiqpvJJQ5wVRdzJVpTnANBA5qxeA==]
     -   - nested thing 2.0
         - nested thing 2.1
+```
+
+Reading large eyaml values from files
+-------------------------------------
+
+Sometimes, for extremely large encrypted values, you might find it easier to store the encrypted information in a single file. In addition to reading from .eyaml files, hiera-eyaml can read key-value pairs from a file, where the filename is the key, and the contents of the file is an encrypted value. When hiera searches the hierarchy, eyaml will look for a directory called `<hierarchy>.d`, and if it exists, will look for keys as files in this directory.
+
+example:
+
+```
+hiera.yaml:
+
+:hierarchy:
+    - %{environment}
+    - common
+
+
+common.d/some_thing:
+
+ENC[PKCS7,Y22exl+OvjDe+drmik2XEeD3VQtl1uZJXFFF2NnrMXDWx0csyqLB/2NOWefvNBTZfOlPvMlAesyr4bUY4I5XeVbVk38XKxeriH69EFAD4CahIZlC8lkE/uDhjJGQfh052eonkungHIcuGKY/5sEbbZl/qufjAtp/ufor15VBJtsXt17tXP4yl5ZP119Fwq8xiREGOL0lVvFYJz2hZc1ppPCNG5lwuLnTekXN/OazNYpf4CMd/HjZFXwcXRtTlzewJLc+/gox2IfByQRhsI/AgogRfYQKocZgFb/DOZoXR7wmIZGeunzwhqfmEtGiqpvJJQ5wVRdzJVpTnANBA5qxeA==]
+
+common.yaml:
+
+some_thing: ENC[PKCS7,Y22exl+OvjDe+drmik2XEeD3VQtl1uZJXFFF2NnrMXDWx0csyqLB/2NOWefvNBTZfOlPvMlAesyr4bUY4I5XeVbVk38XKxeriH69EFAD4CahIZlC8lkE/uDhjJGQfh052eonkungHIcuGKY/5sEbbZl/qufjAtp/ufor15VBJtsXt17tXP4yl5ZP119Fwq8xiREGOL0lVvFYJz2hZc1ppPCNG5lwuLnTekXN/OazNYpf4CMd/HjZFXwcXRtTlzewJLc+/gox2IfByQRhsI/AgogRfYQKocZgFb/DOZoXR7wmIZGeunzwhqfmEtGiqpvJJQ5wVRdzJVpTnANBA5qxeA==]
+
+(the last 2 are equivalent ways of setting a "some_thing" key with an encrypted value)
 ```
 
 Configuration file for eyaml

--- a/lib/hiera/backend/eyaml.rb
+++ b/lib/hiera/backend/eyaml.rb
@@ -2,7 +2,7 @@ class Hiera
   module Backend
     module Eyaml
 
-      VERSION = "2.0.6"
+      VERSION = "2.1.0"
       DESCRIPTION = "Hiera-eyaml is a backend for Hiera which provides OpenSSL encryption/decryption for Hiera properties"
 
       class RecoverableError < StandardError

--- a/lib/hiera/backend/eyaml_backend.rb
+++ b/lib/hiera/backend/eyaml_backend.rb
@@ -28,12 +28,20 @@ class Hiera
 
         Backend.datasources(scope, order_override) do |source|
           debug("Looking for data source #{source}")
-          eyaml_file = Backend.datafile(:eyaml, scope, source, extension) || next
 
-          next unless File.exists?(eyaml_file)
+          eyaml_file = Backend.datafile(:eyaml, scope, source, extension)
+          dir_of_files = Backend.datafile(:eyaml, scope, scource, "d")
 
-          data = @cache.read(eyaml_file, Hash) do |data|
-            YAML.load(data) || {}
+          data = if eyaml_file
+            next unless File.exists?(eyaml_file)
+
+            @cache.read(eyaml_file, Hash) do |data|
+              YAML.load(data) || {}
+            end
+          else if dir_of_files
+            path = File.join(dir_of_files, key)
+            next unless File.exist? path
+            File.read path
           end
 
           next if data.empty?

--- a/lib/hiera/backend/eyaml_backend.rb
+++ b/lib/hiera/backend/eyaml_backend.rb
@@ -30,20 +30,23 @@ class Hiera
           debug("Looking for data source #{source}")
 
           eyaml_file = Backend.datafile(:eyaml, scope, source, extension)
-          dir_of_files = Backend.datafile(:eyaml, scope, scource, "d")
+          dir_of_files = Backend.datafile(:eyaml, scope, source, "d")
 
           data = if eyaml_file
+            debug("Looking in #{eyaml_file} for #{key}")
             next unless File.exists?(eyaml_file)
 
             @cache.read(eyaml_file, Hash) do |data|
               YAML.load(data) || {}
             end
-          else if dir_of_files
+          elsif dir_of_files
             path = File.join(dir_of_files, key)
+            debug("Looking in #{dir_of_files} for #{dir_of_files}/#{key}")
             next unless File.exist? path
-            File.read path
+            { key => File.read( path ) }
           end
 
+          next if data.nil?
           next if data.empty?
           next unless data.include?(key)
 


### PR DESCRIPTION
Basically include the functionality of the hiera-file backend.

Example:

hierarchy:
- common

Will look in two places to find a key "mykey":
common.eyaml  - where it expects to find a yaml document with key mykey
common.d/mykey - where it will read the contents of this file in as the value

This enables very large encrypted data to not have to be part of a .yaml document.

No tests for this yet.
