### PR TITLE
Add option to ignore the existance of certificates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,38 @@ Github has a great guide on removing sensitive data from repos here:
 https://help.github.com/articles/remove-sensitive-data
 
 
+Host by host enabling
+---------------------
+
+Sometimes you want to be able to enable eyaml on a host-by-host basis when migrating from yaml to eyaml.
+
+This could be done by using the **pkcs7_enforce_certs** config option.
+
+```yaml
+:backends: 
+  - eyaml
+  - yaml
+:yaml:
+    :datadir: /etc/puppet/hieradata
+:eyaml:
+  :datadir: /etc/puppet/hieradata
+  :pkcs7_private_key: /etc/puppet/private_key.pkcs7.pem
+  :pkcs7_public_key:  /etc/puppet/public_key.pkcs7.pem
+  :pkcs7_enforce_certs: false
+  :extension: yaml
+```
+
+Without the pkcs7_enforce_certs option (which defaults to 'true'), puppet would fail if the certificates
+doesn't exist. Meaning, that you can't distribute _one_ hiera.yaml config file everywhere.
+
+So this allows you to distribute one config file everywhere, but once you copy the certificates onto
+the machine, puppet will start decrypting the values correctly. If not, it will simply put a
+
+    <secret>
+
+in place of the encrypted value.
+
+
 Troubleshooting
 ---------------
 


### PR DESCRIPTION
I needed a way to offer host-by-host migration from yaml to eyaml, and this was the only thing I could think of, considering we have **ONE** <code>hiera.yaml</code> file on everything and it would be _a lot_ more work to start distributing different ones onto different machines in different environments etc.

So instead offer the option to _hiera-eyaml_ to ignore missing certificates by setting the option <code>:pkcs7_enforce_certs: false</code> which makes _hiera-eyaml_ not fail if/when the certs are missing. Once they certificates have been copied onto the machine(s), it starts decrypting the values correctly.

It's horribly ugly, and if it can be rewritten cleaner, feel free. Although I know several languages really good, this is the very first I've looked at Ruby (and I'm not impressed! :).
