### PR TITLE
Adds Vault Integration (App_ID and decryption only)

### DIFF
--- a/hiera-eyaml.gemspec
+++ b/hiera-eyaml.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('trollop', '~> 2.0')
   gem.add_dependency('highline', '~> 1.6.19')
+  gem.add_dependency('vault', '~> 0.6.0')
 end

--- a/lib/hiera/backend/eyaml.rb
+++ b/lib/hiera/backend/eyaml.rb
@@ -2,7 +2,7 @@ class Hiera
   module Backend
     module Eyaml
 
-      VERSION = "2.1.1"
+      VERSION = "2.1.2"
       DESCRIPTION = "Hiera-eyaml is a backend for Hiera which provides OpenSSL encryption/decryption for Hiera properties"
 
       class RecoverableError < StandardError

--- a/lib/hiera/backend/eyaml.rb
+++ b/lib/hiera/backend/eyaml.rb
@@ -2,7 +2,7 @@ class Hiera
   module Backend
     module Eyaml
 
-      VERSION = "2.1.0"
+      VERSION = "2.1.1"
       DESCRIPTION = "Hiera-eyaml is a backend for Hiera which provides OpenSSL encryption/decryption for Hiera properties"
 
       class RecoverableError < StandardError

--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -30,7 +30,7 @@ class Hiera
                                 :default => "" },
             :vault_address => { :desc    => "Vault Server Address",
                                 :type    => :string,
-                                :defualt => "" }
+                                :default => "" }
           }
 
           self.tag = "PKCS7"

--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -12,15 +12,21 @@ class Hiera
         class Pkcs7 < Encryptor
 
           self.options = {
-            :private_key => { :desc => "Path to private key", 
-                              :type => :string, 
+            :private_key => { :desc => "Path to private key",
+                              :type => :string,
                               :default => "./keys/private_key.pkcs7.pem" },
-            :public_key => { :desc => "Path to public key",  
-                             :type => :string, 
+            :public_key => { :desc => "Path to public key",
+                             :type => :string,
                              :default => "./keys/public_key.pkcs7.pem" },
             :subject => { :desc => "Subject to use for certificate when creating keys",
                           :type => :string,
                           :default => "/" },
+            :vault_appid => { :desc    => "Vault Application ID",
+                              :type    => :string,
+                              :default => nil },
+            :vault_userid => { :desc    => "Path to Vault User ID",
+                               :type    => :string,
+                               :default => :nil }
           }
 
           self.tag = "PKCS7"
@@ -30,12 +36,12 @@ class Hiera
             public_key = self.option :public_key
             raise StandardError, "pkcs7_public_key is not defined" unless public_key
 
-            public_key_pem = File.read public_key 
+            public_key_pem = File.read public_key
             public_key_x509 = OpenSSL::X509::Certificate.new( public_key_pem )
 
             cipher = OpenSSL::Cipher::AES.new(256, :CBC)
             OpenSSL::PKCS7::encrypt([public_key_x509], plaintext, cipher, OpenSSL::PKCS7::BINARY).to_der
-            
+
           end
 
           def self.decrypt ciphertext


### PR DESCRIPTION
Allows the use of Vault to store public and private keys on the puppet master.

Currently supports Vault's APPID authentication.

Example Configuration:

``` yaml
:eyaml:
  :datadir: "/etc/puppetlabs/code/environments/%{environment}/hieradata"
  :pkcs7_private_key: VAULT[secret/hiera:private]
  :pkcs7_public_key:  VAULT[secret/hiera:public]
  :pkcs7_vault_appid: 69dd5fa3-7320-4b11-ee7c-fb3b1e2b617a
  :pkcs7_vault_userid: /etc/instance-id
  :pkcs7_vault_address: https://myawesomevault.com:8200
```
