### PR TITLE
Modify recrypt command to allow recrypting file with different encryp…

### DIFF
--- a/features/recrypt.feature
+++ b/features/recrypt.feature
@@ -21,3 +21,7 @@ Feature: Recrypt
     Then the exit status should be 1
     And I run `eyaml decrypt -e test_input.eyaml`
     Then the output should match /encrypted_string: DEC::PKCS7\[planet of the apes\]\!/
+    And I run `eyaml recrypt -d plaintext test_input.eyaml`
+    Then the exit status should be 0
+    And I run `eyaml decrypt -e test_input.eyaml`
+    Then the output should match /encrypted_string: DEC::PLAINTEXT\[planet of the apes\]\!/

--- a/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
+++ b/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
@@ -2,6 +2,7 @@ require 'hiera/backend/eyaml/parser/token'
 require 'hiera/backend/eyaml/utils'
 require 'hiera/backend/eyaml/encryptor'
 require 'hiera/backend/eyaml'
+require 'base64'
 
 
 class Hiera
@@ -36,6 +37,11 @@ class Hiera
             label = args[:label]
             label_string = label.nil? ? '' : "#{label}: "
             format = args[:format].nil? ? @format : args[:format]
+            encryption_method = args[:change_encryption]
+            if encryption_method != nil
+              @encryptor = Encryptor.find encryption_method
+              @cipher = Base64.encode64(@encryptor.encrypt @plain_text).strip
+            end
             case format
               when :block
                 # strip any white space

--- a/lib/hiera/backend/eyaml/subcommands/recrypt.rb
+++ b/lib/hiera/backend/eyaml/subcommands/recrypt.rb
@@ -10,7 +10,12 @@ class Hiera
         class Recrypt < Subcommand
 
           def self.options
-            []
+            [
+                 {:name          => :change_encryption,
+                  :description   => "Specify the new encryption method that should be used for the file",
+                  :short         => 'd',
+                  :default       => "pkcs7"}
+             ]
           end
 
           def self.description
@@ -26,6 +31,7 @@ class Hiera
             options[:source] = :eyaml
             options[:eyaml] = ARGV.shift
             options[:input_data] = File.read options[:eyaml]
+            @change_encryption = options[:change_encryption]
             options
           end
 
@@ -38,7 +44,7 @@ class Hiera
             decrypted_parser = Parser::ParserFactory.decrypted_parser
             edited_tokens = decrypted_parser.parse(decrypted_input)
 
-            encrypted_output = edited_tokens.map{ |t| t.to_encrypted }.join
+            encrypted_output = edited_tokens.map{ |t| t.to_encrypted({:change_encryption => @change_encryption}) }.join
 
             filename = Eyaml::Options[:eyaml]
             File.open("#{filename}", 'w') { |file|


### PR DESCRIPTION
The hiera-eyaml has a recrypt command which allows one to recrypt an entire file. Recrypting is done by default using the same encryption method. If the file is encrypted using PKCS7 encryption, every value will be decrypted and re-encrypted using this method.

We extended this command to allow one to specify which encryption method should be use. Using this functionality one can easily move from one encryption method to another.
