### PR TITLE
Suppressing logging of configuration files on init

### DIFF
--- a/lib/hiera/backend/eyaml/subcommand.rb
+++ b/lib/hiera/backend/eyaml/subcommand.rb
@@ -38,7 +38,6 @@ class Hiera
           [ "/etc/eyaml/config.yaml", "#{ENV['HOME']}/.eyaml/config.yaml", "#{ENV['EYAML_CONFIG']}" ].each do |config_file|
             begin
               yaml_contents = YAML.load_file(config_file)
-              LoggingHelper::info "Loaded config from #{config_file}"
               config.merge! yaml_contents
             rescue 
               raise StandardError, "Could not open config file \"#{config_file}\" for reading"


### PR DESCRIPTION
Right now [subcommand.rb](https://github.com/voxpupuli/hiera-eyaml/blob/705eadd91d1807055c20b949ae6fcb94b4533045/lib/hiera/backend/eyaml/subcommand.rb#L41) logs something along the following on start-up if a configuration file exists:

> [hiera-eyaml-core] Loaded config from /home/user/.eyaml/config.yaml

That kind of debugging information is understandable and can be helpful for seeing how your configuration is applied, but it is very bad for non-interactive use. Additionally, the behavior for loading these configuration files is documented in the README, so I am proposing removing those logs for the benefit of being able to properly script `eyaml encrypt` as well as `eyaml decrypt`.