### PR TITLE
Update #{self.prefix} to match yamllint rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,5 @@ branches:
   only:
     - master
     - /^v\d/
+before_install:
+  - gem install bundler

--- a/lib/hiera/backend/eyaml/subcommands/edit.rb
+++ b/lib/hiera/backend/eyaml/subcommands/edit.rb
@@ -26,7 +26,7 @@ class Hiera
           end
 
           def self.prefix
-            '#|'
+            '# |'
           end
 
           def self.preamble
@@ -35,8 +35,8 @@ class Hiera
             }).collect{|name| Encryptor.find(name).tag}
 
             preamble = <<-eos
-This is eyaml edit mode. This text (lines starting with #{self.prefix} at the top of the
-file) will be removed when you save and exit.
+This is eyaml edit mode. This text (lines starting with #{self.prefix} at the top of
+the file) will be removed when you save and exit.
  - To edit encrypted values, change the content of the DEC(<num>)::PKCS7[]!
    block#{(tags.size>1) ? " (or #{tags.drop(1).collect {|tag| "DEC(<num>)::#{tag}[]!" }.join(' or ')})." : '.' }
    WARNING: DO NOT change the number in the parentheses.


### PR DESCRIPTION
yamllint defaults to require-starting-space, this change will fix the
preamble to match the yamllint rules so that inline linting doesn't
throw errors while eyaml editing files.

Signed-off-by: Jordan Conway <jconway@linuxfoundation.org>