### PR TITLE
Add encrypt-only flag for 'edit' command.

### DIFF
--- a/features/edit.feature
+++ b/features/edit.feature
@@ -134,32 +134,32 @@ Feature: eyaml editing
     When I run `eyaml edit --no-preamble test_edit.eyaml`
     Then the stderr should contain "No changes detected"
 
-  Scenario: encrypt-only mode should not decrypt input
+  Scenario: no-decrypt mode should not decrypt input
     Given my EDITOR is set to "/bin/cat"
     When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
-    When I run `eyaml edit --encrypt-only test_input.eyaml`
+    When I run `eyaml edit --no-decrypt test_input.eyaml`
     Then the output should not match /DEC\(\d+\)/
     And the output should match /encrypted_string: ENC\[PKCS7,[^\]]+\]/
 
-  Scenario: encrypt-only mode should encrypt new values
+  Scenario: no-decrypt mode should encrypt new values
     Given my EDITOR is set to "./append.sh test_new_values.yaml"
     When I run `bash -c 'cp test_edit.yaml test_edit.eyaml'`
-    When I run `eyaml edit -y test_edit.eyaml`
+    When I run `eyaml edit -d test_edit.eyaml`
     When I run `eyaml decrypt -e test_edit.eyaml`
     Then the output should match /new_key1: DEC::PKCS7\[new value one\]\!/
     And the output should match /new_key2: DEC::PKCS7\[new value two\]\!/
 
-  Scenario: encrypt-only mode should not modify existing values
+  Scenario: no-decrypt mode should not modify existing values
     Given my EDITOR is set to "./append.sh test_new_values.yaml"
     When I run `bash -c 'cp test_edit.yaml test_edit.eyaml'`
-    When I run `eyaml edit -y test_edit.eyaml`
+    When I run `eyaml edit -d test_edit.eyaml`
     When I run `cat test_edit.eyaml`
     Then the output should contain "encrypted_string: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQAwDQYJKoZIhvcNAQEBBQAEggEAgld+rftjW8WmMwTJLX/3Kk9hQv9ZUufsieijxhnCo3gtR/6xaKdMC4wpYM9Eck7FFdmjz2XnJK9o5rlvjW5ZBH3u2A3tphs6cgy7HzsfrsJvw1Mc+CLSNL35MVi/YvNCxezn+rXn28NW8NntByoLTzZnd6iGxSBk4S7Z7XwvdQWuUjXy0muEeAUYtS/eppNZYdyeMpzE9oHmfMM+zwdOYzc/nfwvnoLHGP+sv6KmnzCyNtqyrdvCIn+m+ljPWpGvj410Q52Xili1Scgi+ALJf4xiEnD5c5YjEkYY8uUe4etCDYZ/aXp9RGvZiHD8Le6jz34fcWbLZlQacCfgcyY8AzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBD4CRz8QLvbtgRx/NTxEnpfgCBLQD1ei8KAcd0LTT7sezZPt6LQnLxPuwx5StflI5xOgA==]"
 
-  Scenario: encrypt-only mode should succeed even if keyfile is unreadable
+  Scenario: no-decrypt mode should succeed even if keyfile is unreadable
     Given my EDITOR is set to "/bin/cat"
     When I run `bash -c 'cp test_edit.yaml test_edit.eyaml'`
-    When I run `eyaml edit -y --pkcs7-private-key=not_a_keyfile test_edit.eyaml`
+    When I run `eyaml edit -d --pkcs7-private-key=not_a_keyfile test_edit.eyaml`
     Then the exit status should be 0
     And the stderr should not contain "No such file or directory"
     And the output should not match /DEC\(\d+\)/

--- a/features/edit.feature
+++ b/features/edit.feature
@@ -134,6 +134,37 @@ Feature: eyaml editing
     When I run `eyaml edit --no-preamble test_edit.eyaml`
     Then the stderr should contain "No changes detected"
 
+  Scenario: encrypt-only mode should not decrypt input
+    Given my EDITOR is set to "/bin/cat"
+    When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
+    When I run `eyaml edit --encrypt-only test_input.eyaml`
+    Then the output should not match /DEC\(\d+\)/
+    And the output should match /encrypted_string: ENC\[PKCS7,[^]]+\]/
+
+  Scenario: encrypt-only mode should encrypt new values
+    Given my EDITOR is set to "./append.sh test_new_values.yaml"
+    When I run `bash -c 'cp test_edit.yaml test_edit.eyaml'`
+    When I run `eyaml edit -y test_edit.eyaml`
+    When I run `eyaml decrypt -e test_edit.eyaml`
+    Then the output should match /new_key1: DEC::PKCS7\[new value one\]\!/
+    And the output should match /new_key2: DEC::PKCS7\[new value two\]\!/
+
+  Scenario: encrypt-only mode should not modify existing values
+    Given my EDITOR is set to "./append.sh test_new_values.yaml"
+    When I run `bash -c 'cp test_edit.yaml test_edit.eyaml'`
+    When I run `eyaml edit -y test_edit.eyaml`
+    When I run `cat test_edit.eyaml`
+    Then the output should contain "encrypted_string: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQAwDQYJKoZIhvcNAQEBBQAEggEAgld+rftjW8WmMwTJLX/3Kk9hQv9ZUufsieijxhnCo3gtR/6xaKdMC4wpYM9Eck7FFdmjz2XnJK9o5rlvjW5ZBH3u2A3tphs6cgy7HzsfrsJvw1Mc+CLSNL35MVi/YvNCxezn+rXn28NW8NntByoLTzZnd6iGxSBk4S7Z7XwvdQWuUjXy0muEeAUYtS/eppNZYdyeMpzE9oHmfMM+zwdOYzc/nfwvnoLHGP+sv6KmnzCyNtqyrdvCIn+m+ljPWpGvj410Q52Xili1Scgi+ALJf4xiEnD5c5YjEkYY8uUe4etCDYZ/aXp9RGvZiHD8Le6jz34fcWbLZlQacCfgcyY8AzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBD4CRz8QLvbtgRx/NTxEnpfgCBLQD1ei8KAcd0LTT7sezZPt6LQnLxPuwx5StflI5xOgA==]"
+
+  Scenario: encrypt-only mode should succeed even if keyfile is unreadable
+    Given my EDITOR is set to "/bin/cat"
+    When I run `bash -c 'cp test_edit.yaml test_edit.eyaml'`
+    When I run `eyaml edit -y --pkcs7-private-key=not_a_keyfile test_edit.eyaml`
+    Then the exit status should be 0
+    And the stderr should not contain "No such file or directory"
+    And the output should not match /DEC\(\d+\)/
+    And the output should match /encrypted_string: ENC\[PKCS7,/
+
   Scenario: EDITOR has a space in it that isn't quoted or escaped
     Given my EDITOR is set to "./path/spaced editor.sh"
     When I run `bash -c 'cp test_input.yaml test_input.eyaml'`

--- a/features/edit.feature
+++ b/features/edit.feature
@@ -139,7 +139,7 @@ Feature: eyaml editing
     When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
     When I run `eyaml edit --encrypt-only test_input.eyaml`
     Then the output should not match /DEC\(\d+\)/
-    And the output should match /encrypted_string: ENC\[PKCS7,[^]]+\]/
+    And the output should match /encrypted_string: ENC\[PKCS7,[^\]]+\]/
 
   Scenario: encrypt-only mode should encrypt new values
     Given my EDITOR is set to "./append.sh test_new_values.yaml"

--- a/lib/hiera/backend/eyaml/subcommands/edit.rb
+++ b/lib/hiera/backend/eyaml/subcommands/edit.rb
@@ -15,9 +15,9 @@ class Hiera
           def self.options
             [{ :name => :no_preamble,
                :description => "Don't prefix edit sessions with the informative preamble" },
-             {:name => :encrypt_only,
-              :description => "Don't try to decrypt before editing.",
-              :short => 'y'}
+             {:name => :no_decrypt,
+              :short => "-d",
+              :description => "Do not decrypt existing encrypted content. New content marked properly will be encrypted."}
             ]
           end
 
@@ -77,7 +77,8 @@ eos
 
             Parser::EncToken.set_encrypt_unchanged(false)
 
-            if Eyaml::Options[:encrypt_only]
+            # The 'no_' option has special handling - bypass that and just check if a flag was set.
+            if Eyaml::Options[:no_decrypt_given]
               decrypted_input = Eyaml::Options[:input_data]
               decrypted_file_content = Eyaml::Options[:no_preamble] ? decrypted_input : (self.preamble + decrypted_input)
             else


### PR DESCRIPTION
Enables editing of files with only access to the public key.
Already-encrypted values will not be decrypted, but new or replaced values
will be encrypted as usual.

This is an attempt to resolve #231. 