### PR TITLE
Use UTF-8 as the encoding for plain text data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 before_install:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
+  - gem update --system $RUBYGEMS_VERSION
   - gem update bundler
   - gem --version
   - bundle -v
@@ -19,7 +19,7 @@ script:
 matrix:
   include:
     - rvm: 2.1.9
-      env: PUPPET_VERSION="~> 4.0"
+      env: PUPPET_VERSION="~> 4.0" RUBYGEMS_VERSION=2.7.8
     - rvm: 2.4.2
       env: PUPPET_VERSION="~> 5.0"
 notifications:

--- a/features/parser.feature
+++ b/features/parser.feature
@@ -20,6 +20,7 @@ Feature: Parser
     Then token 2 should be a EncToken
     Then token 2 should start with "ENC[PKCS7,MIIBiQYJKoZIhvcNAQ"
     Then token 2 should decrypt to start with "planet of the apes"
+    Then token 2 should decrypt to a string with UTF-8 encodings
 
   Scenario: Parse decrypted yaml
     Given I make a parser instance with the DEC regexs

--- a/features/step_definitions/parser_steps.rb
+++ b/features/step_definitions/parser_steps.rb
@@ -42,6 +42,11 @@ Then /^token (\d+) should decrypt to start with "(.*)"$/ do |index, plain|
   token.plain_text.should =~ /^#{Regexp.escape(plain)}/
 end
 
+Then /^token (\d+) should decrypt to a string with UTF-8 encodings$/ do |index|
+  token = @tokens[index.to_i - 1]
+  token.plain_text.encoding.to_s.should == 'UTF-8'
+end
+
 And /^map it to index decrypted values$/ do
   @decrypted = @tokens.each_with_index.to_a.map{ |(t, index)|
     t.to_decrypted :index => index

--- a/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
+++ b/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
@@ -44,7 +44,7 @@ class Hiera
 
           def initialize(format, plain_text, encryptor, cipher, match = '', indentation = '', id = nil)
             @format = format
-            @plain_text = plain_text
+            @plain_text = Utils.convert_to_utf_8( plain_text )
             @encryptor = encryptor
             @cipher = cipher
             @indentation = indentation

--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -50,12 +50,24 @@ class Hiera
             candidates << candidate.to_s.split('::').last if parent_class.const_get(candidate).class.to_s == "Class"
           end
           candidates
-        end 
+        end
 
         def self.hiera?
           "hiera".eql? Eyaml::Options[:source]
         end
 
+        def self.convert_to_utf_8 string
+          orig_encoding = string.encoding
+          return string if orig_encoding == Encoding::UTF_8
+
+          string_copy = string.dup
+          # Attempt to use the default_external encoding as the starting point for Binary encoding.
+          string_copy.force_encoding(Encoding.default_external) if orig_encoding == Encoding::BINARY
+          return string_copy.encode(Encoding::UTF_8)
+        rescue EncodingError => detail
+          warn "Unable to encode to \"Encoding::UTF_8\" using the origional \"#{orig_encoding}\""
+          return string
+        end
       end
     end
   end

--- a/lib/hiera/backend/eyaml/utils.rb
+++ b/lib/hiera/backend/eyaml/utils.rb
@@ -60,12 +60,9 @@ class Hiera
           orig_encoding = string.encoding
           return string if orig_encoding == Encoding::UTF_8
 
-          string_copy = string.dup
-          # Attempt to use the default_external encoding as the starting point for Binary encoding.
-          string_copy.force_encoding(Encoding.default_external) if orig_encoding == Encoding::BINARY
-          return string_copy.encode(Encoding::UTF_8)
+          return string.dup.force_encoding(Encoding::UTF_8)
         rescue EncodingError => detail
-          warn "Unable to encode to \"Encoding::UTF_8\" using the origional \"#{orig_encoding}\""
+          warn "Unable to encode to \"Encoding::UTF_8\" using the original \"#{orig_encoding}\""
           return string
         end
       end


### PR DESCRIPTION
Prior to this PR, the encoding could be anything that the Base64 or decryptor returned. In the case of pkcs7, it was ASCII-8BIT. This PR attempts to convert the encoding to UTF-8 for the plain_text data.

This should resolve #273 as both `Base64` and the `Pkcs7.decrypt` encode the plain text as `ASCII-8BIT`.