### PR TITLE
(doc) Correct order for config file precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Configuration file for eyaml
 
 Default parameters for the eyaml command line tool can be provided by creating a configuration YAML file.
 
-Config files will be read first from `/etc/eyaml/config.yaml`, then from `~/.eyaml/config.yaml` and finally by anything referenced in the `EYAML_CONFIG` environment variable
+Config files will be read first from `~/.eyaml/config.yaml`, then from `/etc/eyaml/config.yaml` and finally by anything referenced in the `EYAML_CONFIG` environment variable
 
 The file takes any long form argument that you can provide on the command line. For example, to override the pkcs7 keys:
 ```yaml


### PR DESCRIPTION

The documentation states that the file `/etc/eyaml/config.yaml` is read first, and then falls to `~/.eyaml/config.yaml`.  This would be an odd way to resolve config as local users normally take priority over global settings, and a quick test proves this isn't the case and the README is wrong....

### Using just a global config.yaml

```
[vagrant@puppet .eyaml]$ cat /etc/eyaml/config.yaml
pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem
pkcs7_public_key: /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem

[vagrant@puppet .eyaml]$ /opt/puppetlabs/puppet/bin/eyaml encrypt -s foo
string: ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCA......
```

### Placing a (broken) config.yaml in `~/.eyaml`

```
[vagrant@puppet .eyaml]$ mv ~/.eyaml/config.yaml_ ~/.eyaml/config.yaml && cat ~/.eyaml/config.yaml
pkcs7_private_key: /etc/puppetlabs/puppet/eyaml/private_key.pkcs7.pem_HOMEDIR
pkcs7_public_key: /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem_HOMEDIR

[vagrant@puppet .eyaml]$ /opt/puppetlabs/puppet/bin/eyaml encrypt -s foo
[hiera-eyaml-core] No such file or directory @ rb_sysopen - /etc/puppetlabs/puppet/eyaml/public_key.pkcs7.pem_HOMEDIR
```

### Conclusion

The `config.yaml` in my homedir is being read first and takes priority which contradicts the docs.

