### PR TITLE
Fix block folding

### DIFF
--- a/lib/hiera/backend/eyaml/encryptor.rb
+++ b/lib/hiera/backend/eyaml/encryptor.rb
@@ -14,7 +14,7 @@ class Hiera
 
         def self.find encryption_scheme = nil
           encryption_scheme = Eyaml.default_encryption_scheme if encryption_scheme.nil?
-          require "hiera/backend/eyaml/encryptors/#{File.basename encryption_scheme.downcase}"          
+          require "hiera/backend/eyaml/encryptors/#{File.basename encryption_scheme.downcase}"
           encryptor_module = Module.const_get('Hiera').const_get('Backend').const_get('Eyaml').const_get('Encryptors')
           encryptor_class = Utils.find_closest_class :parent_class => encryptor_module, :class_name => encryption_scheme
           raise StandardError, "Could not find hiera-eyaml encryptor: #{encryption_scheme}. Try gem install hiera-eyaml-#{encryption_scheme.downcase} ?" if encryptor_class.nil?
@@ -29,7 +29,7 @@ class Hiera
           Base64.decode64(string)
         end
 
-        def self.encrypt *args 
+        def self.encrypt *args
           raise StandardError, "encrypt() not defined for encryptor plugin: #{self}"
         end
 
@@ -80,4 +80,3 @@ class Hiera
     end
   end
 end
-

--- a/lib/hiera/backend/eyaml/encryptor.rb
+++ b/lib/hiera/backend/eyaml/encryptor.rb
@@ -22,7 +22,7 @@ class Hiera
         end
 
         def self.encode binary_string
-          Base64.encode64(binary_string).strip  
+          Base64.strict_encode64(binary_string)
         end
 
         def self.decode string

--- a/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
+++ b/lib/hiera/backend/eyaml/parser/encrypted_tokens.rb
@@ -59,16 +59,12 @@ class Hiera
             encryption_method = args[:change_encryption]
             if encryption_method != nil
               @encryptor = Encryptor.find encryption_method
-              @cipher = Base64.encode64(@encryptor.encrypt @plain_text).strip
+              @cipher = Base64.strict_encode64(@encryptor.encrypt(@plain_text))
             end
             case format
               when :block
-                # strip any white space
-                @cipher = @cipher.gsub(/[ \t]/, "")
-                # normalize indentation
-                ciphertext = @cipher.gsub(/[\n\r]/, "\n" + @indentation)
                 chevron = (args[:use_chevron].nil? || args[:use_chevron]) ? ">\n" : ''
-                "#{label_string}#{chevron}" + @indentation + "ENC[#{@encryptor.tag},#{ciphertext}]"
+                "#{label_string}#{chevron}" + @indentation + "ENC[#{@encryptor.tag},#{@cipher}]".scan(/.{1,60}/).join("\n" + @indentation)
               when :string
                 ciphertext = @cipher.gsub(/[\n\r]/, "")
                 "#{label_string}ENC[#{@encryptor.tag},#{ciphertext}]"

--- a/lib/hiera/backend/eyaml/subcommands/encrypt.rb
+++ b/lib/hiera/backend/eyaml/subcommands/encrypt.rb
@@ -78,7 +78,7 @@ class Hiera
               else
                 encryptor = Encryptor.find
                 ciphertext = encryptor.encode( encryptor.encrypt(Eyaml::Options[:input_data]) )
-                token = Parser::EncToken.new(:block, Eyaml::Options[:input_data], encryptor, ciphertext, nil, '    ')
+                token = Parser::EncToken.new(:block, Eyaml::Options[:input_data], encryptor, ciphertext, nil, '  ')
                 case Eyaml::Options[:output]
                   when "block"
                     token.to_encrypted :label => Eyaml::Options[:label], :use_chevron => !Eyaml::Options[:label].nil?, :format => :block

--- a/lib/hiera/backend/eyaml/subcommands/encrypt.rb
+++ b/lib/hiera/backend/eyaml/subcommands/encrypt.rb
@@ -11,12 +11,12 @@ class Hiera
         class Encrypt < Subcommand
 
           def self.options
-            [{:name => :password, 
-              :description => "Source input is a password entered on the terminal", 
+            [{:name => :password,
+              :description => "Source input is a password entered on the terminal",
               :short => 'p'},
              {:name => :string,
               :description => "Source input is a string provided as an argument",
-              :short => 's', 
+              :short => 's',
               :type => :string},
              {:name => :file,
               :description => "Source input is a regular file",


### PR DESCRIPTION
This pull request improves the format of blocks produced by eyaml.

* Indentation was changed to the more typical YAML indentation of two spaces, instead of four.
* The block is evenly folded, rather than having the first line longer than the rest.

Before:

```yaml
    ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEw
    DQYJKoZIhvcNAQEBBQAEggEAqrb9MgggAdRMD063Nzs8pIVWdfHe0bOXMLD2
    ZufGtM3ZsJux23gmSwRm0Ba86mMofdr+NXc1ErKEdQM3qYHZ02sIaENqOcgd
    dcLTJ1+zC2sBMAg/DbE21wVUGju6QPa6fTiYtGnQLzOKgDgQlqPm4xgU5V5J
    xS0WNJ0eVM+3FsEaw7zjOdg01ooMXUe8qhCBGzf/E0taCMuESU/L5ZsVSfju
    Cew1+AQ1sjzra8b+rW0Xyj9BzIiUOKV+Q1C2e2u7UPKREQueuzNyH8Xf1XWH
    p/ilTHDR1suX/ByRWpK+B0zT3c3eLQi0KvjCnM2rDlglNDHQu5ZGDQ67gNAs
    rZ9o8jA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAHhOZ2CwkrG2wc4K+T
    c1eegBBsuGd8WwZhetIvNgGWXYvf]
```

After:

```yaml
  ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBAD
  AFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAuYmADidSlCIBpX70ZF1Jru2RD9
  KInWspl/19R8xNcsrEZ5XS6lFuXTmLDlWuxj4+JWDZ5d/JDgi7xZOVfeiGdb
  mbVmS54+2/INDMxGI+0nCnzYuxHAl/y4VEE4RKF2NMoBHdzke0QpTirsJJbm
  md8+hMUVHiKepNotYNlYd06usZp6vXUsqnmwjuJqJg0zzA9LPvUmlzIK6pnl
  85r4WW2WGdO3byGEmAanyTn9P6ENv0SuxrrWDUKIG1HfPcu5xvUMTh0ei9eb
  BQAmxY6aOKCMWZUnsdW1FF19yejf2+SBrXJZDk67NjamXD4co36OuLlKA2KA
  ow87kGlsQ+lHoVhTA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBDpBywfdQ
  qNcuulHx2HE5AigBAM8EnE1YqBmqe7+WZIPPRK]
```