### PR TITLE
Gemfile: use upstream github_changelog_generator again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   gem "puppet", ENV['PUPPET_VERSION'] || default_puppet_restriction
   gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
   if RUBY_VERSION >= '2.2.2'
-    gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/voxpupuli/github-changelog-generator', :branch => 'voxpupuli_essential_fixes'
+    gem 'github_changelog_generator',  :require => false
     gem "activesupport", activesupport_restriction
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   gem "puppet", ENV['PUPPET_VERSION'] || default_puppet_restriction
   gem 'json_pure', '<= 2.0.1' if RUBY_VERSION < '2.0.0'
   if RUBY_VERSION >= '2.2.2'
-    gem 'github_changelog_generator',  :require => false
+    gem 'github_changelog_generator', :require => false
     gem "activesupport", activesupport_restriction
   end
 end


### PR DESCRIPTION
The fix in voxpupuli_essential_fixes was merged upstream in <https://github.com/github-changelog-generator/github-changelog-generator/pull/797>, so we don't need to use this voxpupuli fork anymore.