### PR TITLE
Unpin highline

### DIFF
--- a/hiera-eyaml.gemspec
+++ b/hiera-eyaml.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency('optimist')
-  gem.add_dependency('highline', '~> 1.6.19')
+  gem.add_dependency('highline')
 end


### PR DESCRIPTION
This unpins highline as the bug that cause it to be pinned only occurs
in Ruby < 1.9.3. Considering Ruby 1.9.2 was EOL in July 2014, this seems
safe to be able to update now.

This pin is currently blocking us being able to use [vmfloaty](https://github.com/puppetlabs/vmfloaty) in Bolt
development environments, as Bolt depends on this gem and vmfloaty pulls
in `command 4.5.2` which requires `highline (~> 2.0.0)`. We can work
around this by locally patching this change and pulling in the gem from
the filepath, but it'd be great if this pin was removed and it could
just work.

Let me know your thoughts!