### PR TITLE
remove question mark from regex in encrypted? method

### DIFF
--- a/lib/hiera/backend/eyaml_backend.rb
+++ b/lib/hiera/backend/eyaml_backend.rb
@@ -99,7 +99,7 @@ class Hiera
       end
 
       def encrypted?(data)
-        /.*ENC\[.*?\]/ =~ data ? true : false
+        /.*ENC\[.*\]/ =~ data ? true : false
       end
 
       def parse_answer(data, scope, extra_data={})


### PR DESCRIPTION
## Changes

As discussed on this PR https://github.com/voxpupuli/puppet-syntax/pull/127/files

The question mark is irrelevant in this REGEX, so with the IAC team, we decided to fix it from the upstream project.

Thanks!