### PR TITLE
Fix an "undefined method" error with rubygems >= 3.3.0

### DIFF
--- a/lib/hiera/backend/eyaml/plugins.rb
+++ b/lib/hiera/backend/eyaml/plugins.rb
@@ -31,7 +31,8 @@ class Hiera
           [index].flatten.each do |source|
             specs = Gem::VERSION >= "1.6.0" ? source.latest_specs(true) : source.latest_specs
 
-            specs.each do |spec|
+            specs.each do |stub|
+              spec = Gem::VERSION >= "3.2.33" ? stub.to_spec : stub
               next if @@plugins.include? spec
 
               dependency = spec.dependencies.find { |d| d.name == "hiera-eyaml" }

--- a/lib/hiera/backend/eyaml/plugins.rb
+++ b/lib/hiera/backend/eyaml/plugins.rb
@@ -25,21 +25,22 @@ class Hiera
 
         def self.find
 
+          gem_version = Gem::Version.new(Gem::VERSION)
           this_version = Gem::Version.create(Hiera::Backend::Eyaml::VERSION)
-          index = Gem::VERSION >= "1.8.0" ? Gem::Specification : Gem.source_index
+          index = gem_version >= Gem::Version.new("1.8.0") ? Gem::Specification : Gem.source_index
 
           [index].flatten.each do |source|
-            specs = Gem::VERSION >= "1.6.0" ? source.latest_specs(true) : source.latest_specs
+            specs = gem_version >= Gem::Version.new("1.6.0") ? source.latest_specs(true) : source.latest_specs
 
             specs.each do |stub|
-              spec = Gem::VERSION >= "3.2.33" ? stub.to_spec : stub
+              spec = gem_version >= Gem::Version.new("3.2.33") ? stub.to_spec : stub
               next if @@plugins.include? spec
 
               dependency = spec.dependencies.find { |d| d.name == "hiera-eyaml" }
               next if dependency && !dependency.requirement.satisfied_by?( this_version )
 
               file = nil
-              if Gem::VERSION >= "1.8.0"
+              if gem_version >= Gem::Version.new("1.8.0")
                 file = spec.matches_for_glob("**/eyaml_init.rb").first
               else
                 file = Gem.searcher.matching_files(spec, "**/eyaml_init.rb").first

--- a/lib/hiera/backend/eyaml/plugins.rb
+++ b/lib/hiera/backend/eyaml/plugins.rb
@@ -33,7 +33,7 @@ class Hiera
             specs = gem_version >= Gem::Version.new("1.6.0") ? source.latest_specs(true) : source.latest_specs
 
             specs.each do |stub|
-              spec = gem_version >= Gem::Version.new("3.2.33") ? stub.to_spec : stub
+              spec = gem_version >= Gem::Version.new("3.3.0") ? stub.to_spec : stub
               next if @@plugins.include? spec
 
               dependency = spec.dependencies.find { |d| d.name == "hiera-eyaml" }


### PR DESCRIPTION
https://github.com/rubygems/rubygems/commit/ae3980eed01ed17c186ceb4094adef185864512e changed `Gem::Specification.latest_specs` to return `Gem::StubSpecification` objects instead of `Gem::Specification` objects. That broke hiera-eyaml which expects the objects to have a `dependencies` method:

```
$ eyaml
Traceback (most recent call last):
	7: from /usr/local/bin/eyaml:23:in `<main>'
	6: from /usr/local/bin/eyaml:23:in `load'
	5: from /var/lib/gems/2.7.0/gems/hiera-eyaml-3.2.2/bin/eyaml:10:in `<top (required)>'
	4: from /var/lib/gems/2.7.0/gems/hiera-eyaml-3.2.2/lib/hiera/backend/eyaml/plugins.rb:31:in `find'
	3: from /var/lib/gems/2.7.0/gems/hiera-eyaml-3.2.2/lib/hiera/backend/eyaml/plugins.rb:31:in `each'
	2: from /var/lib/gems/2.7.0/gems/hiera-eyaml-3.2.2/lib/hiera/backend/eyaml/plugins.rb:34:in `block in find'
	1: from /var/lib/gems/2.7.0/gems/hiera-eyaml-3.2.2/lib/hiera/backend/eyaml/plugins.rb:34:in `each'
/var/lib/gems/2.7.0/gems/hiera-eyaml-3.2.2/lib/hiera/backend/eyaml/plugins.rb:37:in `block (2 levels) in find': undefined method `dependencies' for #<Gem::StubSpecification:0x0000559da19dd520> (NoMethodError)
```