### PR TITLE
README: Add apt to installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Setup
 
     $ gem install hiera-eyaml
     
-#### Aptitude (Ubuntu 18.04+)
+#### Apt (Ubuntu 18.04+)
 
     $ sudo apt install hiera-eyaml
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ Setup
 
 ### Installing hiera-eyaml
 
+#### RubyGems
+
     $ gem install hiera-eyaml
+    
+#### Aptitude (Ubuntu 18.04+)
+
+    $ sudo apt install hiera-eyaml
 
 ### Installing hiera-eyaml for the new [puppet-server](https://github.com/puppetlabs/puppet-server)
 


### PR DESCRIPTION
Specifies the command to install `hiera-eyaml` using the apt package manager, typically on Ubuntu OS.
The Ubuntu version requirement has been obtained from: https://packages.ubuntu.com/search?keywords=hiera-eyaml&searchon=names&suite=all&section=all
The original installation method using `gem` has been in a "RubyGems" section. 