### PR TITLE
CI: Ensure we use Puppet 6.29 or newer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - "3.1"
         puppet:
           - "~> 7.0"
-          - "~> 6.0"
+          - "~> 6.29"
           - "https://github.com/puppetlabs/puppet.git#main"
         exclude:
           - ruby: "2.6"
@@ -30,9 +30,9 @@ jobs:
             puppet: "~> 7.0"
 
           - ruby: "3.1"
-            puppet: "~> 6.0"
+            puppet: "~> 6.29"
           - ruby: "3.0"
-            puppet: "~> 6.0"
+            puppet: "~> 6.29"
 
           - ruby: "2.6"
             puppet: "https://github.com/puppetlabs/puppet.git#main"


### PR DESCRIPTION
Puppet 6.28 and older allow concurreny-ruby 1.X. 1.2 introduced a breaking chhange. This is fixed in Puppet 6.29.