### PR TITLE
Run puppet main branch on Ruby 3.1 and newer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test
 
 on:
-  - pull_request
-  - push
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 env:
   BUNDLE_WITHOUT: release
@@ -63,3 +65,11 @@ jobs:
         run: gem build *.gemspec
       - name: Run tests
         run: bundle exec cucumber -f progress
+
+  tests:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
           - ruby: "3.0"
             puppet: "~> 6.29"
 
+          - ruby: "3.0"
+            puppet: "https://github.com/puppetlabs/puppet.git#main"
+          - ruby: "2.7"
+            puppet: "https://github.com/puppetlabs/puppet.git#main"
           - ruby: "2.6"
             puppet: "https://github.com/puppetlabs/puppet.git#main"
           - ruby: "2.5"


### PR DESCRIPTION
main got moved to puppet 8 which now requires Ruby 3.1 or newer.