### PR TITLE
Puppet 7: Ensure we test against 7.24 or newer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,14 @@ jobs:
           - "3.1"
           - "3.2"
         puppet:
-          - "~> 7.0"
+          - "~> 7.24"
           - "~> 6.29"
           - "https://github.com/puppetlabs/puppet.git#main"
         exclude:
           - ruby: "2.6"
-            puppet: "~> 7.0"
+            puppet: "~> 7.24"
           - ruby: "2.5"
-            puppet: "~> 7.0"
+            puppet: "~> 7.24"
 
           - ruby: "3.2"
             puppet: "~> 6.29"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,10 @@
 name: Test
 
 on:
-  - pull_request
-  - push
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 env:
   BUNDLE_WITHOUT: release
@@ -63,3 +65,11 @@ jobs:
         run: gem build *.gemspec
       - name: Run tests
         run: bundle exec cucumber -f progress
+
+  tests:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
           - ruby: "3.0"
             puppet: "~> 6.29"
 
+          - ruby: "3.0"
+            puppet: "https://github.com/puppetlabs/puppet.git#main"
+          - ruby: "2.7"
+            puppet: "https://github.com/puppetlabs/puppet.git#main"
           - ruby: "2.6"
             puppet: "https://github.com/puppetlabs/puppet.git#main"
           - ruby: "2.5"


### PR DESCRIPTION
There was a fuckup with concurrent-ruby 1.2.0 release which dropped a
private API that puppet used. newer Puppet versions (7.22 and newer)
depend on concurrent-ruby < 1.2.0. We need to force ~> puppet 7.22
installation to ensure bundler doesn't pull in a newer concurrent-ruby
and older Puppet version.