### PR TITLE
Drop Ruby 2.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.5"
           - "2.6"
           - "2.7"
           - "3.0"
@@ -34,12 +33,8 @@ jobs:
             puppet: "~> 8.0"
           - ruby: "2.6"
             puppet: "~> 8.0"
-          - ruby: "2.5"
-            puppet: "~> 8.0"
 
           - ruby: "2.6"
-            puppet: "~> 7.24"
-          - ruby: "2.5"
             puppet: "~> 7.24"
 
           - ruby: "3.2"
@@ -54,8 +49,6 @@ jobs:
           - ruby: "2.7"
             puppet: "https://github.com/puppetlabs/puppet.git#main"
           - ruby: "2.6"
-            puppet: "https://github.com/puppetlabs/puppet.git#main"
-          - ruby: "2.5"
             puppet: "https://github.com/puppetlabs/puppet.git#main"
     env:
       PUPPET_VERSION: ${{ matrix.puppet }}

--- a/hiera-eyaml.gemspec
+++ b/hiera-eyaml.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('optimist')
   gem.add_dependency('highline')
 
-  gem.required_ruby_version = '>= 2.5.0', ' < 4'
+  gem.required_ruby_version = '>= 2.6', ' < 4'
 end


### PR DESCRIPTION
We're moving all modules and gems that are installed on a puppetserver to Ruby 2.6 or newer. That's the jruby equivalent for Puppetserver 7.