### PR TITLE
Load configuration file from working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,11 @@ Configuration file for eyaml
 
 Default parameters for the eyaml command line tool can be provided by creating a configuration YAML file.
 
-Config files will be read first from `~/.eyaml/config.yaml`, then from `/etc/eyaml/config.yaml` and finally by anything referenced in the `EYAML_CONFIG` environment variable
+Config files will be read in following order:
+* first from system-wide `/etc/eyaml/config.yaml`
+* then from user home directory `~/.eyaml/config.yaml`
+* then from current working directory `.eyaml/config.yaml`
+* finally by anything referenced in the `EYAML_CONFIG` environment variable
 
 The file takes any long form argument that you can provide on the command line. For example, to override the pkcs7 keys:
 ```yaml

--- a/lib/hiera/backend/eyaml/subcommand.rb
+++ b/lib/hiera/backend/eyaml/subcommand.rb
@@ -35,7 +35,7 @@ class Hiera
         
         def self.load_config_file
           config = { :options => {}, :sources => [] }
-          [ "/etc/eyaml/config.yaml", "#{ENV['HOME']}/.eyaml/config.yaml", "#{ENV['EYAML_CONFIG']}" ].each do |config_file|
+          [ "/etc/eyaml/config.yaml", "#{ENV['HOME']}/.eyaml/config.yaml", ".eyaml/config.yaml", "#{ENV['EYAML_CONFIG']}" ].each do |config_file|
             begin
               yaml_contents = YAML.load_file(config_file)
               config[:options].merge! yaml_contents


### PR DESCRIPTION
Aside from global configuration in /etc and home directory, search for eyaml configuration in current working directory. This could be very helpful when working with multiple repositories encrypted with different keys.