### PR TITLE
CI: Allow running github actions on all branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - '*'
 
 env:
   BUNDLE_WITHOUT: release


### PR DESCRIPTION
1. All running tests on feature branches
2. ~Remove Ruby 2.6 from matrix as it was now excluded from all tests~ Fixed by PR #369
3. ~Remove "spec tests" as it is the exact same as "Run tests"~ Fixed by PR #375 