### PR TITLE
Drop Ruby 2.6 leftovers in CI config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"
@@ -30,11 +29,6 @@ jobs:
             puppet: "~> 8.0"
           - ruby: "2.7"
             puppet: "~> 8.0"
-          - ruby: "2.6"
-            puppet: "~> 8.0"
-
-          - ruby: "2.6"
-            puppet: "~> 7.24"
 
           - ruby: "3.0"
             puppet: "https://github.com/puppetlabs/puppet.git#main"


### PR DESCRIPTION
We dropped support for it in https://github.com/voxpupuli/hiera-eyaml/pull/366