### PR TITLE
CI: Dont run tests twice

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,6 @@ jobs:
         run: bundle exec rake features
       - name: Verify gem builds
         run: gem build --strict --verbose *.gemspec
-      - name: Run tests
-        run: bundle exec cucumber -f progress
 
   tests:
     needs:


### PR DESCRIPTION
Previously we run tests for via the rake task and then again directly. That's stupid.