### PR TITLE
Add more jruby interpreter to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - jruby-9.4
         puppet:
           - "~> 8.0"
           - "~> 7.24"
@@ -46,8 +47,6 @@ jobs:
           - ruby: "3.0"
             puppet: "https://github.com/puppetlabs/puppet.git#main"
           - ruby: "2.7"
-            puppet: "https://github.com/puppetlabs/puppet.git#main"
-          - ruby: "2.6"
             puppet: "https://github.com/puppetlabs/puppet.git#main"
     env:
       PUPPET_VERSION: ${{ matrix.puppet }}


### PR DESCRIPTION
It makes sense to test and jruby and alternatives. hiera lookups via puppetserver are executed via jruby.