### PR TITLE
Remove non-essential public certificate attributes

### DIFF
--- a/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
+++ b/lib/hiera/backend/eyaml/encryptors/pkcs7.rb
@@ -20,15 +20,9 @@ class Hiera
                                    type: :string, },
             public_key_env_var: { desc: 'Name of environment variable to read public key from',
                                   type: :string, },
-            subject: { desc: 'Subject to use for certificate when creating keys',
-                       type: :string,
-                       default: '/', },
             keysize: { desc: 'Key size used for encryption',
                        type: :integer,
                        default: 2048, },
-            digest: { desc: 'Hash function used for PKCS7',
-                      type: :string,
-                      default: 'SHA256', },
           }
 
           self.tag = 'PKCS7'
@@ -57,23 +51,21 @@ class Hiera
           end
 
           def self.create_keys
-            # Try to do equivalent of:
-            # openssl req -x509 -nodes -days 100000 -newkey rsa:2048 -keyout privatekey.pem -out publickey.pem -subj '/'
+            # Do equivalent of:
+            # openssl req -x509 -nodes -newkey rsa:2048 -keyout privatekey.pem -out publickey.pem -batch
 
             public_key = option :public_key
             private_key = option :private_key
-            subject = option :subject
             keysize = option :keysize
-            digest = option :digest
 
             key = OpenSSL::PKey::RSA.new(keysize)
             EncryptHelper.ensure_key_dir_exists private_key
             EncryptHelper.write_important_file filename: private_key, content: key.to_pem, mode: 0o600
 
             cert = OpenSSL::X509::Certificate.new
-            cert.subject = OpenSSL::X509::Name.parse(subject)
-            cert.serial = 1
-            cert.version = 2
+            # In JRuby implementation of openssl, not_before and not_after
+            # are required to sign cert with key and digest. Signing the
+            # certificate is only required for Ruby 2.7 to call cert.to_pem.
             cert.not_before = Time.now
             cert.not_after = if 1.size == 8 # 64bit
                                Time.now + (50 * 365 * 24 * 60 * 60)
@@ -81,18 +73,7 @@ class Hiera
                                Time.at(0x7fffffff)
                              end
             cert.public_key = key.public_key
-
-            ef = OpenSSL::X509::ExtensionFactory.new
-            ef.subject_certificate = cert
-            ef.issuer_certificate = cert
-            cert.extensions = [
-              ef.create_extension('basicConstraints', 'CA:TRUE', true),
-              ef.create_extension('subjectKeyIdentifier', 'hash'),
-            ]
-            cert.add_extension ef.create_extension('authorityKeyIdentifier',
-                                                   'keyid:always,issuer:always')
-
-            cert.sign key, OpenSSL::Digest.new(digest)
+            cert.sign key, OpenSSL::Digest.new('SHA256')
 
             EncryptHelper.ensure_key_dir_exists public_key
             EncryptHelper.write_important_file filename: public_key, content: cert.to_pem


### PR DESCRIPTION
The following certificate attributes have no use in the encryption or decryption process as it is implemented in hiera-eyaml:
- subject
- version
- digest type
- extensions

These attributes are required when executing with JRuby to sign the certificate:
- begin date
- end date

The attributes that are always essential are the serial number and the public key. When left unset, the serial number is generated randomly or set to 0, which is fine in the context of hiera-eyaml.