### PR TITLE
adjust CLI newline printing to fix output not matching input

### DIFF
--- a/lib/hiera/backend/eyaml/CLI.rb
+++ b/lib/hiera/backend/eyaml/CLI.rb
@@ -42,7 +42,7 @@ class Hiera
           executor = Eyaml::Options[:executor]
 
           result = executor.execute
-          puts result unless result.nil?
+          executor.print_out(result) unless result.nil?
         end
       end
     end

--- a/lib/hiera/backend/eyaml/subcommand.rb
+++ b/lib/hiera/backend/eyaml/subcommand.rb
@@ -135,6 +135,10 @@ class Hiera
           options
         end
 
+        def self.print_out(string)
+          print string
+        end
+
         def self.validate(args)
           args
         end

--- a/lib/hiera/backend/eyaml/subcommands/decrypt.rb
+++ b/lib/hiera/backend/eyaml/subcommands/decrypt.rb
@@ -81,6 +81,17 @@ class Hiera
               decrypted.join
             end
           end
+
+          def self.print_out(string)
+            case Eyaml::Options[:source]
+            when :eyaml
+              # Be sure the output ends with a newline, since YAML is a text format.
+              puts string
+            else
+              # Print the exact result.
+              print string
+            end
+          end
         end
       end
     end

--- a/lib/hiera/backend/eyaml/subcommands/encrypt.rb
+++ b/lib/hiera/backend/eyaml/subcommands/encrypt.rb
@@ -90,6 +90,18 @@ class Hiera
               end
             end
           end
+
+          def self.print_out(string)
+            case Eyaml::Options[:output]
+            when 'string'
+              # Do not include a newline, so that 'eyaml decrypt' of the
+              # output returns the original input.
+              print string
+            else
+              # The output is a text file, so ensure there is a final newline.
+              puts string
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Prior to this change, sending the output of 'eyaml encrypt -s string' to the input of 'eyaml decrypt' can result in output that does not match the original.

    $ echo -n foo | sha1sum
    0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33  -
    $ echo -n foo | eyaml encrypt --stdin -o string | eyaml decrypt --stdin | sha1sum
    f1d2d2f924e986ac86fdf7b36c94bcdf32beec15  -

Additionally, running 'eyaml decrypt' on unencrypted data does not pass the data through unchanged.

    $ echo -n foo | eyaml decrypt --stdin | sha1sum
    f1d2d2f924e986ac86fdf7b36c94bcdf32beec15  -

There are three reasons for this:
1. For data that is not enclosed in an 'ENC[]', eyaml decryption returns that data unchanged; this includes leading and trailing data. A trailing newline does not get any special consideration in this regard.
2. The output of 'eyaml encrypt -s string' always includes a trailing newline.
3. The output of 'eyaml decrypt' always includes a trailing newline.

In general, trailing newlines are good for line-oriented data (such as a text file), but this behavior can corrupt other output that does not happen to include a trailing newline (such as binary data or arbitrary text strings). Additionally, if the input to 'eyaml encrypt' already has a trailing newline, then the output from 'eyaml decrypt' ends up with two newlines.

With this change:
1. The 'string' output of 'eyaml encrypt' no longer has a trailing newline.
2. The output of 'eyaml decrypt' no longer enforces a trailing newline, except when the input is eyaml data  (in which case a trailing newline is desirable, since YAML is a text-file format).

https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.new_line_at_end_of_file

This fixes:
https://github.com/voxpupuli/hiera-eyaml/issues/270
https://github.com/voxpupuli/hiera-eyaml/issues/272
(except for block output/input, which should probably be a separate issue)