### PR TITLE
Run cucumber in strict mode

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,7 @@ end
 # https://stackoverflow.com/questions/6473419/using-simplecov-to-display-cucumber-code-coverage
 require 'cucumber/rake/task'
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = %w[--format progress] # Any valid command line option can go here.
+  t.cucumber_opts = %w[--format progress --strict] # Any valid command line option can go here.
 end
 
 begin


### PR DESCRIPTION
By default, cucumber do not return an error when some step definitions are missing: it only produce an informational message with code snippet before exiting.

On CI, this is "lost" and when we break a test, it may seem the CI is passing while in fact the test is just broken and not tested anymore.

When running in strict mode, cucumber will exit with an error in such condition.
