### PR TITLE
Remove base64 dependency from hiera-eyaml.gemspec

### DIFF
--- a/hiera-eyaml.gemspec
+++ b/hiera-eyaml.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'base64', '~> 0.3.0'
   gem.add_dependency 'highline', '>= 2.1', '< 4'
   gem.add_dependency 'optimist', '~> 3.1'
 


### PR DESCRIPTION
This is a default gem in Ruby 3.2 and a bundled gem in 4.0. Declaring it in the gemspec causes problems when using OpenVox 8 since it is at version 0.1.1. But we should not need to declare the dependency anyway since it's a default/bundled gem.