### PR TITLE
Change base64 dependency version constraint

### DIFF
--- a/hiera-eyaml.gemspec
+++ b/hiera-eyaml.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'base64', '~> 0.3.0'
+  gem.add_dependency 'base64', '~> 0.1'
   gem.add_dependency 'highline', '>= 2.1', '< 4'
   gem.add_dependency 'optimist', '~> 3.1'
 


### PR DESCRIPTION
Requiring 0.3 breaks with Ruby 3.2. Relaxing to 0.1 so it works properly with Ruby 3 up through 4.