### PR TITLE
recrypt: preserve existing encryption method by default

### DIFF
--- a/features/recrypt.feature
+++ b/features/recrypt.feature
@@ -42,3 +42,12 @@ Feature: Recrypt
     Then the exit status should be 0
     And I run `eyaml decrypt -e test_input.eyaml`
     Then the output should match /encrypted_string: DEC::PKCS7\[planet of the apes\]\!/
+
+  Scenario: Recrypt without --change-encryption preserves the existing encryption method
+    When I run `bash -c 'cp test_input.yaml test_input.eyaml'`
+    And I run `eyaml recrypt -d plaintext test_input.eyaml`
+    Then the exit status should be 0
+    And I run `eyaml recrypt test_input.eyaml`
+    Then the exit status should be 0
+    And I run `eyaml decrypt -e test_input.eyaml`
+    Then the output should match /encrypted_string: DEC::PLAINTEXT\[planet of the apes\]\!/

--- a/lib/hiera/backend/eyaml/subcommands/recrypt.rb
+++ b/lib/hiera/backend/eyaml/subcommands/recrypt.rb
@@ -10,9 +10,9 @@ class Hiera
           def self.options
             [
               { name: :change_encryption,
-                description: 'Specify the new encryption method that should be used for the file',
+                description: 'Specify the new encryption method that should be used for the file (defaults to keeping the existing encryption method of each value)',
                 short: 'd',
-                default: 'pkcs7', },
+                type: :string, },
             ]
           end
 


### PR DESCRIPTION
The --change-encryption (-d) option defaulted to 'pkcs7', so running 'eyaml recrypt <file>' with no flags silently re-encrypted every value with PKCS7, even values encrypted with another method such as GPG. If no PKCS7 public key was present it failed with:

  [hiera-eyaml-core] file ./keys/public_key.pkcs7.pem does not exist

and if a key was present it silently converted secrets to PKCS7.

Drop the default so the option only takes effect when given explicitly. Without it, each value is re-encrypted with its original scheme (the decrypted parser already regenerates the cipher per token from its DEC::TAG marker). Add a feature scenario covering the preserved-scheme behaviour.

Fixes #301, #317, #292