### PR TITLE
CI: Exclude ruby 3.1/jruby9.4 for openvox main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,14 @@ jobs:
           - ruby: "2.7"
             openvox: "~> 8"
 
+          - ruby: "3.1"
+            openvox: "https://github.com/openvoxproject/puppet.git#main"
           - ruby: "3.0"
             openvox: "https://github.com/openvoxproject/puppet.git#main"
           - ruby: "2.7"
+            openvox: "https://github.com/openvoxproject/puppet.git#main"
+
+          - ruby: jruby-9.4
             openvox: "https://github.com/openvoxproject/puppet.git#main"
 
     env:


### PR DESCRIPTION
main is getting prepared for openvox 9 and requires Ruby 3.2.